### PR TITLE
Fix a crash that happens when expanding screenshots.

### DIFF
--- a/app/src/main/java/de/r4md4c/gamedealz/detail/DetailsFragment.kt
+++ b/app/src/main/java/de/r4md4c/gamedealz/detail/DetailsFragment.kt
@@ -138,7 +138,7 @@ class DetailsFragment : BaseFragment() {
 
         detailsViewModel.screenshots.observe(this, Observer { screenshots ->
             gameDetailsAdapter.add(
-                ExpandableScreenshotsHeader {
+                ExpandableScreenshotsHeader(screenshots.size > spanCount) {
                     applyRestOfScreenshots(isExpanded).also { isExpanded = !isExpanded }
                 }
             )

--- a/app/src/main/java/de/r4md4c/gamedealz/detail/item/ExpandableScreenshotsHeader.kt
+++ b/app/src/main/java/de/r4md4c/gamedealz/detail/item/ExpandableScreenshotsHeader.kt
@@ -20,6 +20,7 @@ package de.r4md4c.gamedealz.detail.item
 import android.annotation.SuppressLint
 import android.view.View
 import androidx.core.view.ViewCompat
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.fastadapter.items.AbstractItem
 import de.r4md4c.gamedealz.R
@@ -27,7 +28,10 @@ import kotlinx.android.synthetic.main.layout_expandable_screenshot_header_item.v
 
 typealias OnExpandClick = ExpandableScreenshotsHeader.() -> Unit
 
-class ExpandableScreenshotsHeader(private val onExpandClick: OnExpandClick) :
+class ExpandableScreenshotsHeader(
+    private val showExpandIcon: Boolean,
+    private val onExpandClick: OnExpandClick
+) :
     AbstractItem<ExpandableScreenshotsHeader, ExpandableScreenshotsHeader.ViewHolder>() {
 
 
@@ -37,6 +41,7 @@ class ExpandableScreenshotsHeader(private val onExpandClick: OnExpandClick) :
         super.bindView(holder, payloads)
         val item = this
         with(holder.itemView) {
+            expand_icon.isVisible = showExpandIcon
             ViewCompat.animate(expand_icon).cancel()
             expand_icon.setOnClickListener {
                 onExpandClick()


### PR DESCRIPTION
If the displayed screenshots are less than 3 and the user clicks the expand button it crashes.